### PR TITLE
Adding support for One-To-Many relationships

### DIFF
--- a/CPDKd.py
+++ b/CPDKd.py
@@ -232,7 +232,6 @@ def process_config_msg(msg, zmq_pub_socket):
             ref_model = user_models[msg['f']]
             try:
                 q_ref_obj = session.query(ref_model.__class__).filter(ref_model.__class__.name == msg['fv']).one()
-
                 getattr(q_result, msg['rv']).append(q_ref_obj)
                 session.commit()
 

--- a/cpdk_db.py
+++ b/cpdk_db.py
@@ -37,6 +37,11 @@ class CPDKModel(object):
 
         # Get all the attributes
         for column in self.__class__.__table__.columns:
+
+            # If the column has a foreign key, skip it.
+            if column.foreign_keys:
+                continue
+
             data[column.name] = getattr(self, column.name)
 
         # Get any relations

--- a/docs/create_models.rst
+++ b/docs/create_models.rst
@@ -16,8 +16,104 @@ Let's start with a simple example of defining how we'd like to represent an empl
         salary = Column(Float)
         manager = Column(Boolean)
 
+        display_name = 'employee'
+
 Great! Our minion, er, employee, will have simple attributes such as first and last name, a salary, and a boolean to
 note if they're a manager.
+
+
+Model Relationships
+-------------------
+What fun is a database without relations? Don't answer that if you're a big-data fanboy, please. In this section, we'll
+show how to add relations between database tables.
+
+By defining relationships between models, CPDK will automatically generate the CLI commands to allow users to configure
+those relationships. Additionally, CPDK will automatically generate the C++ methods to notify a daemon when the relationship
+is established.
+
+One To Many
+^^^^^^^^^^^
+The first type of relationship is the one-to-many type. In this scneario, one model can be linked multiple times to
+another model.
+
+Let's start by expanding our previous ``EmployeeModel`` example by adding a DepartmentModel. Since this is a
+one-to-many relationship, we'll say that a department can have multiple employees (but not vice versa) ::
+
+    from sqlalchemy.orm import relationship
+
+    ...
+
+    class DepartmentModel(CPDKModel):
+        cost_code = Column(Integer)
+        email_alias = Column(String)
+        employees = relationship("EmployeeModel")
+
+        display_name = 'department'
+
+Now back in our ``EmployeeModel``, a ``ForeignKey`` is needed to instruct the ORM schema that we intend to link the two
+models.
+
+The new EmployeeModel class looks like this: ::
+
+    class EmployeeModel(CPDKModel):
+        first_name = Column(String)
+        last_name = Column(String)
+        salary = Column(Float)
+        manager = Column(Boolean)
+        department_id = Column(Integer, ForeignKey('departmentmodel.id')
+
+The little bit of glue between these two models is performed by the department_id field. Note that it's just another
+Integer-typed Column but this time it has a ForeignKey associated with it.
+
+**STOP. Read this next line. Seriously.**
+
+SQLAlchemy requires your foreign key name to be lowercase. Yes, it's just the model name, just lower-cased.
+
+Great, now that the two models are linked, go ahead and update your database schema by running ``cpdk-util.py --syncdb``.
+While you're at it, let's re-generate the CLI schema too: ``cpdk-util.py --buildcli``.
+
+If you run CPDKd and RedShell you'll notice that the department mode now has an add/remove sub-command. These automatically
+generated commands allow you to add and remove employees to a department record.
+
+example: ::
+
+    Global> employee Frank
+    employee-Frank>exit
+    Global> department sales
+    department-sales> add EmployeeModel Frank
+    department-sales> show department
+    employees: ['Frank']
+    department-sales>
+
+**TODO:** *Use the display name when adding/removing a relationship. Right now, the model name must be used.*
+
+Many To Many
+^^^^^^^^^^^^
+Another powerful relationship type is the many-to-many. In this situation, each side of the relationship can have
+one or more links to the opposing side. Extending our Employee/Department scenario, let's say that Employees can now
+be in mutliple departments. *Departments can still have multiple employees.*
+
+SQLAlchemy achieves this by having a separate *association table*. ::
+
+    emp_dep_map = Table('Employee_Department_Map', CPDKModel.metadata,
+                        Column('employe_id', Integer, ForeignKey('employeemodel.id')),
+                        Column('department_id', Integer, ForeignKey('departmentmodel.id')))
+
+This model defines both sides of the relationship. As such, no ForeignKey is needed in the other models anymore. Our
+employee and department models now look like this: ::
+
+    class DepartmentModel(CPDKModel):
+        cost_code = Column(Integer)
+        email_alias = Column(String)
+        employees = relationship("EmployeeModel", secondary=emp_dep_map)
+        display_name = 'department'
+
+    class EmployeeModel(CPDKModel):
+        first_name = Column(String)
+        last_name = Column(String)
+        salary = Column(Float)
+        manager = Column(Boolean)
+        departments = relationship("DepartmentModel", secondary=emp_dep_map)
 
 Special Members
 ---------------
@@ -61,3 +157,26 @@ In the example below, the enabled command will be negated with a new command, 'd
 
     enabled = Column(Boolean, default=False,
                      info={'negative_cmd': 'disabled'})
+
+Custom 'show' command output
+----------------------------
+Every model has a CLI 'show' command generated for it by the '--buildcli' mode of ``cpdk-util.py``. By default,
+every field in the model will simply be output as a key/value listing when the show command is run. By defining a
+static ``show(data)`` function on the model, you can override that behavior.
+
+The function will be passed a dictionary of data that can be used to access field values. The method needs to
+return a string that will be printed to the output stream. ::
+
+   class ServerModel(CPDKModel):
+       port = Column(Integer)
+       address = Column(String)
+
+       @staticmethod
+       def show(data):
+           output = '=====%s=====\n' % data['name']
+           output += 'port: %s\n' % data['port']
+           output += 'address: %s\n' % data['address']
+           return output
+
+Remember, every model automatically has ``name`` and ``id`` parameters (defined in CPDKModel) which will be part of the
+data dictionary.

--- a/examples/basic/c_src/Interface.h
+++ b/examples/basic/c_src/Interface.h
@@ -27,9 +27,7 @@ public:
 
     
 
-    virtual void on_id(int val) { }
-virtual void on_name(std::string val) { }
-virtual void on_enabled(bool val) { }
+    virtual void on_enabled(bool val) { }
 virtual void on_packets_out(uint64_t val) { }
 virtual void on_packets_in(uint64_t val) { }
 
@@ -133,11 +131,7 @@ void InterfaceMgr::Init(Interface_Create create_cb, Interface_Delete delete_cb, 
 
             if(value.is_null())
                 continue;
-if(field == "id") {
-    pObj->on_id(value);
-} else if(field == "name") {
-    pObj->on_name(value);
-} else if(field == "enabled") {
+if(field == "enabled") {
     pObj->on_enabled(value);
 } else if(field == "packets_out") {
     pObj->on_packets_out(value);
@@ -286,11 +280,7 @@ void InterfaceMgr::ProcessMessageQueue(void) {
             std::string field = data["field"];
             auto value = data["value"];
 
-if(field == "id") {
-    pObj->on_id(value);
-} else if(field == "name") {
-    pObj->on_name(value);
-} else if(field == "enabled") {
+if(field == "enabled") {
     pObj->on_enabled(value);
 } else if(field == "packets_out") {
     pObj->on_packets_out(value);

--- a/examples/basic/c_src/VirtualServer.h
+++ b/examples/basic/c_src/VirtualServer.h
@@ -20,6 +20,8 @@ using json = nlohmann::json;
 // Forward declarations
 class Server;
 class ServerMgr;
+class VIP;
+class VIPMgr;
 
 
 class VirtualServer {
@@ -29,12 +31,11 @@ public:
 
     virtual void on_add_Server(std::string name) { }
 virtual void on_remove_Server(std::string name) { }
+virtual void on_add_VIP(std::string name) { }
+virtual void on_remove_VIP(std::string name) { }
 
 
-    virtual void on_id(int val) { }
-virtual void on_name(std::string val) { }
-virtual void on_address(std::string val) { }
-virtual void on_port(int val) { }
+    virtual void on_port(int val) { }
 virtual void on_enabled(bool val) { }
 
 
@@ -137,13 +138,7 @@ void VirtualServerMgr::Init(VirtualServer_Create create_cb, VirtualServer_Delete
 
             if(value.is_null())
                 continue;
-if(field == "id") {
-    pObj->on_id(value);
-} else if(field == "name") {
-    pObj->on_name(value);
-} else if(field == "address") {
-    pObj->on_address(value);
-} else if(field == "port") {
+if(field == "port") {
     pObj->on_port(value);
 } else if(field == "enabled") {
     pObj->on_enabled(value);
@@ -152,6 +147,11 @@ if(field == "id") {
 if(field == "servers") {
    for(auto &obj : value) {
       pObj->on_add_Server(obj);
+   }
+}
+else if(field == "vips") {
+   for(auto &obj : value) {
+      pObj->on_add_VIP(obj);
    }
 }
 
@@ -295,13 +295,7 @@ void VirtualServerMgr::ProcessMessageQueue(void) {
             std::string field = data["field"];
             auto value = data["value"];
 
-if(field == "id") {
-    pObj->on_id(value);
-} else if(field == "name") {
-    pObj->on_name(value);
-} else if(field == "address") {
-    pObj->on_address(value);
-} else if(field == "port") {
+if(field == "port") {
     pObj->on_port(value);
 } else if(field == "enabled") {
     pObj->on_enabled(value);
@@ -319,6 +313,9 @@ if(field == "id") {
             if(field == "Server") {
     pObj->on_add_Server(value);
 }
+else if(field == "VIP") {
+    pObj->on_add_VIP(value);
+}
 
             (void)pObj; // Prevent compiler warnings
         } break;
@@ -332,6 +329,9 @@ if(field == "id") {
 
             if(field == "Server") {
     pObj->on_remove_Server(value);
+}
+else if(field == "VIP") {
+    pObj->on_remove_VIP(value);
 }
 
             (void)pObj; // Prevent compiler warnings

--- a/examples/basic/c_src/main.cpp
+++ b/examples/basic/c_src/main.cpp
@@ -1,6 +1,8 @@
 #include "Server.h"
 #include "VirtualServer.h"
 #include "Interface.h"
+#include "VIP.h"
+
 #include <unistd.h>
 #include <signal.h>
 
@@ -9,6 +11,13 @@ public:
     inline MyVirtual(std::string name) : VirtualServer(name) {}
     virtual void on_add_Server(std::string name) {std::cout << "adding server: " << name << std::endl;}
     virtual void on_remove_Server(std::string name) {std::cout << "removing server: " << name << std::endl;}
+    virtual void on_add_VIP(std::string name) {
+        std::cout << "Adding VIP (" << name << ") to virtual server (" << this->GetName() << ")" << std::endl;
+    }
+
+    virtual void on_remove_VIP(std::string name) {
+        std::cout << "Removing VIP (" << name << ") from virtual server (" << this->GetName() << ")" << std::endl;
+    }
 };
 
 // Callbacks for creating and deleting servers

--- a/examples/basic/models/model.py
+++ b/examples/basic/models/model.py
@@ -29,35 +29,51 @@ class Server(CPDKModel):
     virtual_servers = relationship('VirtualServer',
                                    secondary=Server_VS_Map)
 
-    def __str__(self):
-
-        output = '%s\n' % self.name
-        output += '===================\n'
-        output = 'Server: %s\n' % self.name
-        output += '\tAddress: %s\n' % self.address
-        output += '\tPort: %s\n' % self.port
-        output += '\tEnabled: %s\n' % self.enabled
+    @staticmethod
+    def show(data):
+        output = '%s\n' % data['name']
+        output += '\tPort: %s\n' % data['port']
+        output += '\tEnabled: %s\n' % data['enabled']
         return output
 
 
-class VirtualServer(CPDKModel):
+class VIP(CPDKModel):
     address = Column(String)
+    virtual_id = Column(Integer, ForeignKey('virtualserver.id'))
+
+    def __str__(self):
+        return self.address
+
+
+class VirtualServer(CPDKModel):
     port = Column(Integer)
     enabled = Column(Boolean,
                      info={'negative_cmd': 'disabled'})
+
+    # Servers associated with this virtual server (many-to-many)
     servers = relationship('Server',
                            secondary=Server_VS_Map)
 
+    # List of VIP's associated with this virtual server (many-to-one)
+    vips = relationship('VIP')
+
     display_name = 'virtual'
 
-    def __str__(self):
-        output =  'Virtual Server: %s\n' % self.name
-        output += '\tAddress: %s\n' % self.address
-        output += '\tPort: %s\n' % self.port
-        output += '\tEnabled: %s\n' % self.enabled
+    @staticmethod
+    def show(data):
+        output = 'Virtual Server: %s\n' % data['name']
+        output += '\tPort: %s\n' % data['port']
+        output += '\tEnabled: %s\n' % data['enabled']
 
-        if len(self.servers):
+        if len(data['vips']):
+            output += '\tVirtual IPs:\n'
+            for vip in data['vips']:
+                output += '\t\t%s\n' % vip
+            output += '\n'
+
+        if len(data['servers']):
             output += '\tServers:\n'
-        for server in self.servers:
-            output += '\t\t%s\n' % server
+            for server in data['servers']:
+                output += '\t\t%s\n' % server
+
         return output

--- a/tests/redshell/test_redshell.py
+++ b/tests/redshell/test_redshell.py
@@ -52,21 +52,53 @@ class RedShellTest(TestCase):
         c.expect('virtual-Vippy>')
         c.sendline('port 1234')
         c.expect('virtual-Vippy>')
-        c.sendline('address 1.1.1.1')
-        c.expect('virtual-Vippy>')
         c.sendline('exit')
         c.expect('Global>')
         c.sendline('show virtual Vippy')
         c.expect('Global>')
 
         # Make sure the appropriate fields are present
-        self.assertIn('Address: 1.1.1.1', c.before)
         self.assertIn('Port: 1234', c.before)
         self.assertIn('Enabled: False', c.before)
         self.assertIn('Virtual Server: Vippy', c.before)
         c.sendline('exit')
         c.close()
 
+    def test_vip_to_virtual_server(self):
+        """
+        Verify that you can add and remove VIP from a virtual server
+        :return:
+        """
+        c = pexpect.spawn('python redshell.py --settings examples.basic.settings')
+        c.logfile = sys.stdout
+        c.expect('Global>')
+        c.sendline('vip myvip')
+        c.expect('vip-myvip>')
+        c.sendline('address 1.1.1.1')
+        c.expect('vip-myvip>')
+        c.sendline('exit')
+        c.expect('Global>')
+        c.sendline('virtual vs')
+        c.expect('virtual-vs>')
+        c.sendline('add VIP myvip')
+        c.expect('virtual-vs>')
 
+        # Validate the VIP is in the virtual's list
+        c.sendline('show virtual vs')
+        c.expect('virtual-vs>')
+        self.assertIn('myvip', c.before)
 
+        # Remove the VIP and validate it's no longer in the list
+        c.sendline('remove VIP myvip')
+        c.expect('virtual-vs>')
+        c.sendline('show virtual vs')
+        c.expect('virtual-vs>')
+        self.assertNotIn('myvip', c.before)
+
+        c.sendline('exit')
+        c.expect('Global>')
+        c.sendline('show virtual vs')
+        c.expect('Global>')
+        c.sendline('exit')
+        c.close()
 


### PR DESCRIPTION
Change list for issue #44 

Fixed a bug with name/id commands showing up in CLI
No longer allow fields with ForeignKeys to be in CLI
Re-wrote import inspection to use SQLAlchemy inspection
Re-wrote custom show logic to use a staticmethod. Can't instantiate a "normal" method without all fo the class data. Not possible with ForeignKeys (yet)